### PR TITLE
Prevent Dialogue Advance While Paused

### DIFF
--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -172,10 +172,7 @@ public class PlayerController : MonoBehaviour
 
     public void TryAdvanceDialogue()
     {
-        if (GameManager.Instance.GameStateMachine.GetState() != GameState.PAUSE)
-        {
-            DialogueManager.Instance.TryAdvanceDialogue();
-        }
+        DialogueManager.Instance.TryAdvanceDialogue();
     }
 
     private void FixedUpdate()

--- a/Assets/Scripts/UI/Dialogue/DialoguePlayer.cs
+++ b/Assets/Scripts/UI/Dialogue/DialoguePlayer.cs
@@ -142,6 +142,8 @@ public class DialoguePlayer : MonoBehaviour
 
     public void TryAdvanceDialogue()
     {
+        if (GameManager.Instance.GameStateMachine.GetState() == GameState.PAUSE) return;
+
         // If currently fading, in cinematic mode, or at the very start of a dialogue, don't advance
         if (isFading || !acceptingInput) return;
 


### PR DESCRIPTION
Don't allow the player to advance the dialogue while the game is in the paused state. Closes #222 